### PR TITLE
retain timeoutId from setInterval() in object, provide unstick() function

### DIFF
--- a/jq-sticky-anything.js
+++ b/jq-sticky-anything.js
@@ -62,10 +62,13 @@
       }
 
       createPlaceholder();
-      checkElement = setInterval(function(){stickIt(settings.top,settings.minscreenwidth,settings.maxscreenwidth,settings.zindex,settings.pushup,orgAssignedStyles,orgInlineStyles)},10);
-
+      this.timeoutId = setInterval(function(){stickIt(settings.top,settings.minscreenwidth,settings.maxscreenwidth,settings.zindex,settings.pushup,orgAssignedStyles,orgInlineStyles)},10);
     }
 
+    this.unstick = function(){
+      if (this.timeoutId){ clearTimeout(this.timeoutId); }
+    };
+    
     return this;
   };
 


### PR DESCRIPTION
Store the timeoutId from setInterval() inside the object so it can be used for clearTimeout(). As it is right now if the element being watched is removed from the DOM then errors start piling up quickly.